### PR TITLE
Correct ArXiv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Laura Gwilliams, Graham Flick, Alec Marantz, Liina Pylkkänen, David Poeppel, Jean-Rémi King
 
-- [Paper](https://arxiv.org)
+- [Paper](https://arxiv.org/abs/2208.11488)
 - [Data](https://osf.io/ag3kj/)
 - [Code](https://github.com/kingjr/meg-masc)
 


### PR DESCRIPTION
Hello!  I noticed that the paper link in the README was directing to the main ArXiv page, so here is a little fix! 🤓 